### PR TITLE
fix slab_free funciton and SLAB_DEF macro

### DIFF
--- a/include/utils/slab.h
+++ b/include/utils/slab.h
@@ -29,14 +29,14 @@ typedef struct {
  * @note When using this macro, the blocks are not aligned and the user must
  * make sure the `type` param is properly aligned.
  */
-#define SLAB_DEF(name, type, num)                              \
-	uint8_t name ## _slab_blob[sizeof(type) * num];        \
-	uint32_t name ## _slab_alloc_map[(num + 31) / 32];     \
-	slab_t name = {                                        \
-		.blob = name ## _slab_blob,                    \
-		.size = sizeof(type),                          \
-		.count = num,                                  \
-		.alloc_map = name ## _slab_alloc_map,          \
+#define SLAB_DEF(name, type, num)					\
+	uint8_t name ## _slab_blob[sizeof(type) * num];			\
+	uint32_t name ## _slab_alloc_map[(num + 31) / 32] = { 0 };	\
+	slab_t name = {							\
+		.blob = name ## _slab_blob,				\
+		.size = sizeof(type),					\
+		.count = num,						\
+		.alloc_map = name ## _slab_alloc_map,			\
 	};
 
 /**

--- a/src/slab.c
+++ b/src/slab.c
@@ -49,7 +49,7 @@ int slab_free(slab_t *slab, void *p)
 	size_t i;
 
 	for (i = 0; i < slab->count; i++) {
-		if ((slab->blob + i) == p)
+		if ((slab->blob + (slab->size * i)) == p)
 			break;
 	}
 	if (i >= slab->count)


### PR DESCRIPTION
Since the test did not pass I assume this work is not completely done.
However it breaks libosdp completely when you can only allocate one buffer from the slab.

Signed-off-by: Johan Carlsson <johan.carlsson@teenage.engineering>