### PR TITLE
Change so that queue is fifo. Also fix broken list_pop an list_popleft

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -50,6 +50,9 @@ int list_pop(list_t *list, node_t **node)
 	if (list->tail) {
 		list->tail->next = NULL;
 	}
+	else {
+		list->head = NULL;
+	}
 	return 0;
 }
 
@@ -62,6 +65,9 @@ int list_popleft(list_t *list, node_t **node)
 	list->head = list->head->next;
 	if (list->head) {
 		list->head->prev = NULL;
+	}
+	else {
+		list->tail = NULL;
 	}
 	return 0;
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -19,7 +19,7 @@ void queue_enqueue(queue_t *queue, queue_node_t *node)
 
 int queue_dequeue(queue_t *queue, queue_node_t **node)
 {
-	return list_pop(&queue->list, node);
+	return list_popleft(&queue->list, node);
 }
 
 int queue_peek_last(queue_t *queue, queue_node_t **node)


### PR DESCRIPTION
When my liboscp based application pushed a lot of commands i noticed that it sends the newest command first.
this cannot be the correct behavior for a queue.

When changing it i noticed that list_pop and list_popleft does not clear the head and tail. so using append together with popleft did not work.

Signed-off-by: Johan Carlsson <johan.carlsson@teenage.engineering>