### PR TITLE
Add pid_of() to get the pid of a process by name

### DIFF
--- a/include/utils/procutils.h
+++ b/include/utils/procutils.h
@@ -43,4 +43,52 @@ int write_pid(const char *file);
  */
 int o_redirect(int mode, const char *file);
 
+/*
+ * pid_of() - Return the pid of "exe_name"
+ *
+ * Params:
+ *   exe_name  - Name of the executable of which pid should be returned.
+ *   pomit_arr - Array of pid not to be considered.
+ *   arr_len   - Size of pomit_arr
+ * 
+ *  * Returns:
+ *  0   - Failed. No Process with exe_name found
+ *  > 0 - PID of the process having name "exe_name"
+ * 
+ *  Examples:
+ *    pid_of("test-utils", NULL, 0); // return the pid of the test
+ * 
+ *  Limitations:
+ *    Currently, it doesn't work with scripts or kernel threads.
+ */
+unsigned pid_of(const char* exe_name, unsigned *pomit_arr, size_t arr_len);
+
+
+/*
+ * any_pid_of() - Return the pid of one of the process having "exe_name"
+ *
+ * Params:
+ *   exe_name  - Name of the executable of which pid should be returned.
+ * 
+ *  * Returns:
+ *  0   - Failed. No Process with exe_name found
+ *  > 0 - PID of the process having name "exe_name"
+ * 
+ *  Examples:
+ *    any_pid_of("test-utils"); // return the pid of the test
+ * 
+ *  Limitations:
+ *    Currently, it doesn't work with scripts or kernel threads.
+ */
+unsigned any_pid_of(const char* exe_name);
+
+/*
+ * parse_proc_cmdline0() - Return the arg0 of the process having pid 'pid'
+ *
+ * Params:
+ *   pid  - PID of the process for which arg0 will be returned
+ */
+char *parse_proc_cmdline(unsigned pid, int pos);
+
+
 #endif /* _UTIL_PROCUTILS_H_ */

--- a/tests/test-procutils.c
+++ b/tests/test-procutils.c
@@ -1,0 +1,33 @@
+#include "test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include <unistd.h>
+
+#include <utils/filo.h>
+#include <utils/utils.h>
+#include <utils/procutils.h>
+
+int test_pid_of(void)
+{
+	FILE *pfile = fopen("/proc/self/status", "r");
+	if (pfile == NULL)
+		return -1;
+
+	char filename[200] = { 0 };
+	fscanf(pfile, "Name: %199s", filename);
+	fclose(pfile);
+
+	int pid = any_pid_of(filename);
+	return pid == getpid() ? 0 : -1;
+}
+
+TEST_DEF(procutils)
+{
+	TEST_MOD_INIT();
+
+	TEST_MOD_EXEC( test_pid_of() );
+
+	TEST_MOD_REPORT();
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -25,6 +25,7 @@ TEST_DEF(hashmap);
 TEST_DEF(strutils);
 TEST_DEF(filo);
 TEST_DEF(slab);
+TEST_DEF(procutils);
 
 test_module_t c_utils_test_modules[] = {
 	TEST_MOD(circular_buffer),
@@ -33,6 +34,7 @@ test_module_t c_utils_test_modules[] = {
 	TEST_MOD(strutils),
 	TEST_MOD(filo),
 	TEST_MOD(slab),
+	TEST_MOD(procutils),
 	TEST_MOD_SENTINEL,
 };
 


### PR DESCRIPTION
* Add pid_of() function to get the pid of a process having "exe_name" passed to it as parameter.
* Really handy call. Alternate to calling `system("pidof abcd")`.
