### PR TITLE
Fixed Three Compiler Warnings

### DIFF
--- a/src/strutils.c
+++ b/src/strutils.c
@@ -187,7 +187,7 @@ int strcntchr(char *s, char c)
 
 int strisempty(char *s)
 {
-	while (s && *s != '\0' && isspace(*s))
+	while (s && *s != '\0' && isspace((unsigned char)*s))
 		s++;
 
 	return s == NULL || *s == '\0';
@@ -278,7 +278,7 @@ size_t str_sep_count(const char *str, const char *sep)
 void to_upper(char *s)
 {
 	while (*s) {
-		if (isalpha(*s))
+		if (isalpha((unsigned char)*s))
 			*s &= ~0x20;
 		s++;
 	}
@@ -287,7 +287,7 @@ void to_upper(char *s)
 void to_lower(char *s)
 {
 	while (*s) {
-		if (isalpha(*s))
+		if (isalpha((unsigned char)*s))
 			*s |= 0x20;
 		s++;
 	}


### PR DESCRIPTION
The warning: array subscript has type 'char' [-Wchar-subscripts]

Unit tests pass:
```
------------------------------------------
       goToMain C Unit Test Framework     
------------------------------------------
Testing 'circular_buffer'
  - boundary test
  - probabilistic test
  - single produce single consumer test
  - Result: name:'circular_buffer' total:3 pass:3

Testing 'strlib'
  - Result: name:'strlib' total:2 pass:2

Testing 'hashmap'
  - Inserted 370104 items
  - Iterated over 370104 items
  - Deleted 370104 items
  - Inserted 370104 items
  - Result: name:'hashmap' total:5 pass:5

Testing 'strutils'
  - Result: name:'strutils' total:2 pass:2

Testing 'filo'
  - Result: name:'filo' total:200 pass:200

Testing 'slab'
  - Result: name:'slab' total:1 pass:1

Testing 'procutils'
  - Result: name:'procutils' total:1 pass:1

Testing 'workqueue'
  - Created 5 workers
  - Completed 20 jobs
  - Result: name:'workqueue' total:1 pass:1

Testing 'bus_server'
  - bus server started
  - Result: name:'bus_server' total:1 pass:1

------------------------------------------
                Test Summary              
------------------------------------------
Start Time: 26/05/22-13:09:18 -0500
End Time:   26/05/22-13:09:19 -0500
Executed: 216
Successful: 216
Result: PASS
```