### PR TITLE
Added checks for glibc to ensure compatibility with other stdlibs

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -21,10 +21,12 @@
 #include <utils/channel.h>
 #include <utils/fdutils.h>
 
+#ifdef __GLIBC__
 struct msgbuf {
 	long mtype;		/* message type, must be > 0 */
 	uint8_t mtext[512];	/* message data */
 };
+#endif
 
 struct channel_msgq_s {
 	int send_id;

--- a/src/utils.c
+++ b/src/utils.c
@@ -106,7 +106,7 @@ int64_t millis_since(int64_t last)
 	return millis_now() - last;
 }
 
-#if defined(__linux__) || defined(__APPLE__)
+#if (defined(__linux__) || defined(__APPLE__)) && defined(__GLIBC__)
 #include <execinfo.h>
 void dump_trace(void)
 {


### PR DESCRIPTION
Some code assumes glibc as the standard library which causes problems when compiling the project with other stdlibs like musl. This can be avoided by adding checks for __GLIBC__.