### PR TITLE
Feature/gcc warning errors

### DIFF
--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -28,7 +28,9 @@
 #define BYTE_2(x)                      (uint8_t)(((x) >> 16) & 0xFF)
 #define BYTE_3(x)                      (uint8_t)(((x) >> 24) & 0xFF)
 
+#ifndef BIT
 #define BIT(n)                         (1ull << (n))
+#endif
 #define MASK(n)                        (BIT((n) + 1) - 1)
 #define BIT_IS_SET(m, n)               (bool)((m) & BIT(n))
 #define BIT_SET(m, n)                  ((m) |=  BIT(n))

--- a/src/logger.c
+++ b/src/logger.c
@@ -69,7 +69,7 @@ static const char *get_rel_path(logger_t *ctx, const char *abs_path)
 
 	p = ctx->root_path;
 	q = abs_path;
-	while (*p != '\0' && *q != '\0' && *p == *p) {
+	while (*p != '\0' && *q != '\0' && *p == *q) {
 		p++;
 		q++;
 	}

--- a/src/logger.c
+++ b/src/logger.c
@@ -3,9 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define _GNU_SOURCE		/* See feature_test_macros(7) */
-
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hi,

I'm trying to integrate libosdp into another project, which is using gcc 8.4.0 with '-Werror'.
This has caused a few issues which can easily be resolved I guess.

In case you accept these changes, I can update the PR for libosdp, ignoring the submodule pointing to my fork.

Let me know your thoughts.

Thanks in advance.

Kr,
Bart.