### PR TITLE
renaming new param in (s)list_insert_node to newNode

### DIFF
--- a/include/utils/list.h
+++ b/include/utils/list.h
@@ -63,7 +63,7 @@ int slist_pop(slist_t *list, snode_t *after, snode_t **node);
 int slist_popleft(slist_t *list, snode_t **node);
 
 int slist_remove_node(slist_t *list, snode_t *node);
-void slist_insert_node(slist_t *list, snode_t *after, snode_t *new);
+void slist_insert_node(slist_t *list, snode_t *after, snode_t *newNode);
 
 #ifdef __cplusplus
 }

--- a/include/utils/list.h
+++ b/include/utils/list.h
@@ -39,7 +39,7 @@ int list_popleft(list_t *list, node_t **node);
 
 void list_remove_node(list_t *list, node_t *node);
 int list_remove_nodes(list_t *list, node_t *start, node_t *end);
-void list_insert_node(list_t *list, node_t *after, node_t *new);
+void list_insert_node(list_t *list, node_t *after, node_t *newNode);
 int list_insert_nodes(list_t *list, node_t *after, node_t *start, node_t *end);
 
 /*--- singly-linked list ---*/

--- a/src/list.c
+++ b/src/list.c
@@ -160,21 +160,21 @@ int list_remove_nodes(list_t *list, node_t *start, node_t *end)
 	return 0;
 }
 
-void list_insert_node(list_t *list, node_t *after, node_t *new)
+void list_insert_node(list_t *list, node_t *after, node_t *newNode)
 {
 	node_t *next;
 
 	if (after == NULL) {
 		/* insert at head */
 		next = list->head;
-		list->head = new;
+		list->head = newNode;
 	} else {
 		next = after->next;
-		after->next = new;
+		after->next = newNode;
 	}
-	new->prev = after;
-	new->next = next;
-	next->prev = new;
+  newNode->prev = after;
+  newNode->next = next;
+	next->prev = newNode;
 }
 
 int list_insert_nodes(list_t *list, node_t *after, node_t *start, node_t *end)

--- a/src/list.c
+++ b/src/list.c
@@ -288,15 +288,15 @@ int slist_remove_node(slist_t *list, snode_t *node)
 	return 0;
 }
 
-void slist_insert_node(slist_t *list, snode_t *after, snode_t *new)
+void slist_insert_node(slist_t *list, snode_t *after, snode_t *newNode)
 {
 	if (after == NULL) {
 		/* same as append left */
-		new->next = list->head;
-		list->head = new;
+		newNode->next = list->head;
+		list->head = newNode;
 	} else {
 		/* assert after in list here? */
-		new->next = after->next;
-		after->next = new;
+		newNode->next = after->next;
+		after->next = newNode;
 	}
 }


### PR DESCRIPTION
```new``` is a keyword in C++ thus compiling with C++ causes issues with a param names ```new```.  Renaming the param to ```newNode``` eliminates this issue.

The compile error I was seeing was: ```error: invalid parameter name: 'new' is a keyword```