### PR TITLE
Optionally remove OS dependencies

### DIFF
--- a/include/utils/assert.h
+++ b/include/utils/assert.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-#define __ASSERT_PRINT(fmt, ...) printf(fmt, ##__VA_ARGS__)
+#define __ASSERT_PRINT(fmt, ...) __logger_log(NULL, LOG_EMERG,  __FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
 #define __ASSERT_LOC(test) \
         __ASSERT_PRINT("ASSERTION FAIL [%s] @ %s:%d\n", \

--- a/src/utils.c
+++ b/src/utils.c
@@ -148,12 +148,26 @@ int add_iso8601_utc_datetime(char *buf, size_t size)
 	return strftime(buf, size, "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
 }
 
+#elif defined(NO_OS)
+
+int add_iso8601_utc_datetime(char *buf, size_t size)
+{
+	//TODO: Timestamp Generation
+	ARG_UNUSED(buf);
+	ARG_UNUSED(size);
+	return 0;
+}
+
+// Expect user to provide this function
+extern int64_t usec_now();
+
 #else
 
 #error Platform test failed
 
 #endif
 
+#if !defined(NO_OS)
 int64_t usec_now()
 {
 	int64_t usec;
@@ -173,6 +187,7 @@ void get_time(uint32_t *seconds, uint32_t *micro_seconds)
 	*seconds = tv.tv_sec;
 	*micro_seconds = tv.tv_usec;
 }
+#endif
 
 int64_t usec_since(int64_t last)
 {
@@ -204,6 +219,10 @@ void dump_trace(void)
 	}
 	puts("");
 	free(strings);
+}
+#elif defined(NO_OS)
+void dump_trace(void)
+{
 }
 #else
 void dump_trace(void)


### PR DESCRIPTION
In an effort to make it easier to port LibOSDP to embedded devices, I introduced the `NO_OS` flag (name is up for debate).
If this flag is set, no calls to system functions like `printf`, `puts` or `gettimeofday` will be made.

Instead the user is expected to set a either a custom `logger->puts` function or a logging callback.
For time keeping the user is expected to provide a `usecs_now` function, which is way easier and more useful on embedded devices.

Asserts are redirected to the global logger instead of `printf`.

Fixes #27 