### PR TITLE
Bare metal fixes

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -70,6 +70,9 @@ static inline void logger_log_set_color(logger_t *ctx, const char *color)
 		assert(ret == len);
 		ARG_UNUSED(ret); /* squash warning in Release builds */
 	}
+#else
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(color);
 #endif
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -150,15 +150,19 @@ int add_iso8601_utc_datetime(char *buf, size_t size)
 
 #elif defined(__BARE_METAL__)
 
+#ifndef _TIMEVAL_DEFINED
 struct timeval {
 	long tv_sec;  // seconds since epoch
 	long tv_usec; // microseconds
 };
+#endif
 
+#ifndef _TIMEZONE_DEFINED
 struct timezone {
 	int tz_minuteswest; // minutes west of UTC
 	int tz_dsttime;     // daylight saving time flag
 };
+#endif
 
 int gettimeofday(struct timeval * tp, struct timezone * tzp)
 {

--- a/src/utils.c
+++ b/src/utils.c
@@ -162,12 +162,15 @@ struct timezone {
 
 int gettimeofday(struct timeval * tp, struct timezone * tzp)
 {
+	ARG_UNUSED(tzp);
 	tp->tv_sec = 0;
 	tp->tv_usec = 0;
 	return 0;
 }
 
 int add_iso8601_utc_datetime(char* buf, size_t size) {
+	ARG_UNUSED(buf);
+	ARG_UNUSED(size);
 	return 0;
 }
 


### PR DESCRIPTION
With your newest changes compiling `libosdp-rs` for bare metal almost works. With the following changes I can build `libosdp-rs` with `cargo build --target thumbv6m-none-eabi --no-default-features` without problems on Windows and in WSL.

Fixes #27