### PR TITLE
Fix segmentation fault when adding + 1 to a null pointer

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -106,7 +106,12 @@ int __logger_log(logger_t *ctx, int log_level, const char *file, unsigned long l
 	if (!ctx)
 		ctx = &default_logger;
 
-	file = strrchr(file, PATH_SEPARATOR) + 1;
+	const char *filename = strrchr(file, PATH_SEPARATOR);
+	if (filename)
+	{
+		file = filename + 1;
+	}
+	
 	if (!ctx->cb) {
 		if (log_level < LOG_EMERG ||
 		    log_level >= LOG_MAX_LEVEL ||


### PR DESCRIPTION
### Description  
While upgrading `libosdp` from version 2.1.0 to 3.0.8, I encountered a segmentation fault. The fault occurred almost immediately upon entering the `__cp_setup` function.  

#### Investigation  
After analyzing the issue, I traced the problem to the `LOG_PRINT` macro. Specifically, the error originated in the `__logger_log` function, where the return value of the `strrchr` function was not properly handled.  

As per the [documentation](https://cplusplus.com/reference/cstring/strrchr/), `strrchr` returns a pointer to the last occurrence of the specified character, or a null pointer if the character is not found. In this case, the `file` variable already contained just the filename (not the full file path), meaning no path separator was present. Consequently, `strrchr` returned a null pointer. Adding `1` to a null pointer caused the segmentation fault.  

#### Fix  
I updated the code to handle cases where `strrchr` returns a null pointer, ensuring the macro doesn't attempt to dereference or manipulate invalid pointers.  
