### PR TITLE
Esp platform support rtos based

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -95,7 +95,7 @@ static int terminate_log_line(char *buf, int len)
 
 #define LOG_BUF_LEN 192
 
-__format_printf(5, 6)
+__weak __format_printf(5, 6)
 int __logger_log(logger_t *ctx, int log_level, const char *file, unsigned long line,
 		 const char *fmt, ...)
 {
@@ -111,7 +111,7 @@ int __logger_log(logger_t *ctx, int log_level, const char *file, unsigned long l
 	{
 		file = filename + 1;
 	}
-	
+
 	if (!ctx->cb) {
 		if (log_level < LOG_EMERG ||
 		    log_level >= LOG_MAX_LEVEL ||

--- a/src/utils.c
+++ b/src/utils.c
@@ -131,7 +131,7 @@ int add_iso8601_utc_datetime(char* buf, size_t size)
 	return r;
 }
 
-#elif defined(__linux__) || defined(__APPLE__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(ESP_PLATFORM)
 
 #include <sys/time.h>
 #include <time.h>


### PR DESCRIPTION
Support for ESP targets using ESP-IDF (FreeRTOS)
Adding ESP_PLATFORM ensures:

consistent behavior across platforms

Proposed change

Extend the existing platform detection macros to include ESP:

#if defined(linux) || defined(APPLE) || defined(ESP_PLATFORM)